### PR TITLE
Remove tests for correct line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = tab
 tab_width = 2
 insert_final_newline = true

--- a/index.js
+++ b/index.js
@@ -307,10 +307,6 @@ module.exports = {
 				position: 'above'
 			}
 		],
-		'linebreak-style': [
-			'error',
-			'unix'
-		],
 		'lines-between-class-members': 'error',
 		'max-lines': [
 			'error',


### PR DESCRIPTION
Unfortunately, requiring LF line endings with eslint ~~*and* setting `* text=auto` in `.gitattributes`~~ means that eslint will fail for Windows users who clone any repository that depends on this configuration (in my case, [node-psc-package-bin](https://github.com/joneshf/node-psc-package-bin)). This also means that the tests scripts that rely on eslint will fail, hence the problem I ran into. Thankfully, it's not necessary to enforce consistent line endings this way, as far as I can tell, because `gitattributes` will ensure that line endings are always normalized.

This commit removes the eslint check for line endings and removes the editor configuration that requires LF line endings. While I don't personally use editorcfg, I figured it was consistent with the other change. Keeping it would mean that Windows users using editorcfg would end up inserting LF line endings into files with all CRLF line endings, causing git to emit warning messages about normalization and lead to files that look unmodified in an editor but appear modified in git's staging area.